### PR TITLE
Fix dedicated-server startup crash: move common menu registry out of client-only ClientSetup

### DIFF
--- a/src/main/java/net/appleseed/appleseed/AppleSeed.java
+++ b/src/main/java/net/appleseed/appleseed/AppleSeed.java
@@ -3,7 +3,6 @@ package net.appleseed.appleseed;
 import net.appleseed.appleseed.api.hook.DietHookRegistry;
 import net.appleseed.appleseed.api.query.DietQuery;
 import net.appleseed.appleseed.api.type.IDietGroup;
-import net.appleseed.appleseed.client.ClientSetup;
 import net.appleseed.appleseed.client.DietClientEvents;
 import net.appleseed.appleseed.common.event.BlockFoodEventHandler;
 import net.appleseed.appleseed.common.capability.DietData;
@@ -15,6 +14,7 @@ import net.appleseed.appleseed.common.data.group.DietGroup;
 import net.appleseed.appleseed.common.data.group.DietGroups;
 import net.appleseed.appleseed.common.data.recipe.SimulateRecipe;
 import net.appleseed.appleseed.common.recipe.RecipeRegistry;
+import net.appleseed.appleseed.common.registry.ModMenuTypes;
 import net.appleseed.appleseed.common.data.suite.DietSuites;
 import net.appleseed.appleseed.compat.SandwichCompat;
 import net.appleseed.appleseed.network.OpenDietScreenPacket;
@@ -58,7 +58,7 @@ public class AppleSeed {
 
     public AppleSeed(IEventBus bus, ModContainer container) {
         bus.register(RecipeRegistry.class);
-        ClientSetup.MENU_TYPES.register(bus);
+        ModMenuTypes.MENU_TYPES.register(bus);
         bus.addListener(this::commonSetup);
         bus.addListener(this::registerPayloads);
         bus.addListener(this::onConfigReload);

--- a/src/main/java/net/appleseed/appleseed/client/ClientSetup.java
+++ b/src/main/java/net/appleseed/appleseed/client/ClientSetup.java
@@ -7,11 +7,10 @@ import net.appleseed.appleseed.client.screen.DietMenu;
 import net.appleseed.appleseed.common.data.food.FoodNutritionManager;
 import net.appleseed.appleseed.common.data.group.DietGroups;
 import net.appleseed.appleseed.common.data.suite.DietSuites;
+import net.appleseed.appleseed.common.registry.ModMenuTypes;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.inventory.MenuType;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
@@ -21,21 +20,11 @@ import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
 import net.neoforged.neoforge.client.event.RegisterMenuScreensEvent;
-import net.neoforged.neoforge.common.extensions.IMenuTypeExtension;
 import net.neoforged.neoforge.event.AddReloadListenerEvent;
-import net.neoforged.neoforge.registries.DeferredRegister;
 import org.lwjgl.glfw.GLFW;
-
-import java.util.function.Supplier;
 
 @EventBusSubscriber(modid = AppleSeed.MOD_ID, value = Dist.CLIENT)
 public class ClientSetup {
-
-    public static final DeferredRegister<MenuType<?>> MENU_TYPES =
-            DeferredRegister.create(Registries.MENU, AppleSeed.MOD_ID);
-
-    public static final Supplier<MenuType<DietMenu>> DIET_MENU =
-            MENU_TYPES.register("diet", () -> IMenuTypeExtension.create(DietMenu::new));
 
     public static final KeyMapping DIET_KEY = new KeyMapping(
             "key.appleseed.diet",
@@ -51,7 +40,7 @@ public class ClientSetup {
 
     @SubscribeEvent
     public static void registerScreens(RegisterMenuScreensEvent event) {
-        event.register(DIET_MENU.get(), DietScreen::new);
+        event.register(ModMenuTypes.DIET_MENU.get(), DietScreen::new);
     }
 
     @EventBusSubscriber(modid = AppleSeed.MOD_ID, value = Dist.CLIENT)

--- a/src/main/java/net/appleseed/appleseed/common/registry/ModMenuTypes.java
+++ b/src/main/java/net/appleseed/appleseed/common/registry/ModMenuTypes.java
@@ -1,0 +1,23 @@
+package net.appleseed.appleseed.common.registry;
+
+import net.appleseed.appleseed.AppleSeed;
+import net.appleseed.appleseed.client.screen.DietMenu;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.world.inventory.MenuType;
+import net.neoforged.neoforge.common.extensions.IMenuTypeExtension;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+import java.util.function.Supplier;
+
+// Common (both-dist) menu registry. Kept out of client.ClientSetup so the dedicated server can
+// register the diet container without initializing that client-only class -- its KeyMapping field
+// trips NeoForge's RuntimeDistCleaner ("invalid dist DEDICATED_SERVER"). DietMenu is a plain
+// AbstractContainerMenu and is server-safe. The registered id is unchanged: appleseed:diet.
+public class ModMenuTypes {
+
+    public static final DeferredRegister<MenuType<?>> MENU_TYPES =
+            DeferredRegister.create(Registries.MENU, AppleSeed.MOD_ID);
+
+    public static final Supplier<MenuType<DietMenu>> DIET_MENU =
+            MENU_TYPES.register("diet", () -> IMenuTypeExtension.create(DietMenu::new));
+}


### PR DESCRIPTION
Fixes #3.

This is the fix for that crash. It only happens on dedicated servers at startup, single player and clients are fine.

## Stack trace

```
Failed to create mod instance. ModID: appleseed, class net.appleseed.appleseed.AppleSeed
Caused by: java.lang.RuntimeException: Attempted to load class net/minecraft/client/KeyMapping
for invalid dist DEDICATED_SERVER
at net.appleseed.appleseed.client.ClientSetup.<clinit>(ClientSetup.java:40)
at net.appleseed.appleseed.AppleSeed.<init>(AppleSeed.java:60)
```
## Root cause

`AppleSeed`'s constructor (which runs on both sides) calls `ClientSetup.MENU_TYPES.register(bus)`. `MENU_TYPES` is a common menu registry, but it lived inside `ClientSetup`, a client-only class (`@EventBusSubscriber(Dist.CLIENT)`) that also has `public static final KeyMapping DIET_KEY`. Touching `MENU_TYPES` makes java load the whole `ClientSetup` class, which builds the client-only `KeyMapping`. A dedicated server is not allowed to load that, so it throws and mod construction fails.

## The fix

- New file `common/registry/ModMenuTypes.java` holds `MENU_TYPES` and `DIET_MENU`, moved out of `ClientSetup` as is.
- `AppleSeed` now calls `ModMenuTypes.MENU_TYPES.register(bus)`.
- `ClientSetup` keeps `DIET_KEY` and the keybind/screen/tick handlers (those are correctly client-only) and just points `registerScreens` at `ModMenuTypes.DIET_MENU`.

`DietMenu` is a plain `AbstractContainerMenu` with no client-only references, so the server can register the container without loading any client class.

## Compatibility

This only changes where the registry is declared, not what gets registered or its id. The menu is still registered as `appleseed:diet` with the same factory and the same network packets, so a patched build looks identical to stock 2.0.3 on the registry and network side. A patched server still works with stock 2.0.3 clients, and a patched client behaves the same as a stock one. No config, data or API changes.

## Testing
- `./gradlew build` passes (Java 21, NeoForge 21.1.186, which is what the mod builds against).
- Client / single player: works. The diet GUI opens and renders fine after the move, from all the entry points (B keybind, the inventory Diet button, `/diet screen`), and nutrition, effects and tooltips all work. This covers the moved `ModMenuTypes.DIET_MENU` and the `RegisterMenuScreensEvent` mapping. (The crash is dedicated-server only, so single player cannot reproduce it, this just confirms the move did not break the client.)
- Dedicated server: works, tested on NeoForge 21.1.233. A real dedicated server gets past mod construction with no `RuntimeDistCleaner` / `invalid dist DEDICATED_SERVER` error and runs normally (world load and chunk pre-gen). A patched client connects and opens the diet GUI against it.
- Stock 2.0.3 client to patched server: not tested on its own, but it should behave the same, the menu id (`appleseed:diet`), factory and packets are identical to stock 2.0.3 so there is no protocol difference (see Compatibility).